### PR TITLE
Fix bar2vtk path resolving

### DIFF
--- a/bin/bar2vtk.py
+++ b/bin/bar2vtk.py
@@ -48,7 +48,7 @@ import sys
 if args.vptpath:
     vptPath = args.vptpath
 else:
-    vptPath = Path(__file__).absolute().parent.parent
+    vptPath = Path(__file__).resolve().parent.parent
 sys.path.insert(0, vptPath.as_posix())
 
 import vtkpytools as vpt


### PR DESCRIPTION
 - When symlinked, `bar2vtk` would not reference the correct path for the `vtkpytools` repository. 