### PR TITLE
fix: Fix Cf calculation, add calcWallShearGradient

### DIFF
--- a/vtkpytools/bar2vtk/__init__.py
+++ b/vtkpytools/bar2vtk/__init__.py
@@ -1,5 +1,6 @@
 from .core import form2DGrid, computeEdgeNormals
 from .data import (binaryVelbar, binaryStsbar, calcCf, calcReynoldsStresses,
-                   calcBoundaryLayerStats, compute_vorticity, sampleDataBlockProfile)
+                   calcBoundaryLayerStats, compute_vorticity, sampleDataBlockProfile,
+                   calcWallShearGradient)
 
 __name__ = "bar2vtk"

--- a/vtkpytools/bar2vtk/data.py
+++ b/vtkpytools/bar2vtk/data.py
@@ -83,7 +83,9 @@ def calcWallShearGradient(wall):
 
         (delta_ik - n_k n_i) n_j e_kj
 
-    where n_j e_kj is the "traction" vector at the wall.
+    where n_j e_kj is the "traction" vector at the wall. See post at
+    https://www.jameswright.xyz/post/wall_shear_gradient_from_velocity_gradient/
+    for derivation of method.
 
     Parameters
     ----------


### PR DESCRIPTION
 - Cf calculation used wrong definition for du/dn
 - Calculation of du/dn now done in calcWallShearGradient

Derivation of the (new) method for calculating wall shear gradient is found at [my website](https://www.jameswright.xyz/post/wall_shear_gradient_from_velocity_gradient/).