### PR TITLE
Feat: Better barfile selection in bar2vtk

### DIFF
--- a/bin/bar2vtk.py
+++ b/bin/bar2vtk.py
@@ -89,10 +89,10 @@ if '-' in args.timestep:
     print('Creating timewindow between {} and {}'.format(timesteps[0], timesteps[1]))
     velbarPaths = []; stsbarPaths = []
     for timestep in timesteps:
-        velbarPaths.append(vpt.globFile('velbar*{}*'.format(timestep), args.barfiledir))
+        velbarPaths.append(vpt.globFile('velbar*.{}*'.format(timestep), args.barfiledir))
 
         if not args.velonly:
-            stsbarPaths.append(vpt.globFile('stsbar*{}*'.format(timestep), args.barfiledir))
+            stsbarPaths.append(vpt.globFile('stsbar*.{}*'.format(timestep), args.barfiledir))
 
     print('Using data files:\n\t{}\t{}'.format(velbarPaths[0], velbarPaths[1]))
     if not args.velonly:
@@ -111,12 +111,12 @@ if '-' in args.timestep:
                        stsbarArrays[0]*(timesteps[0] - args.ts0)) / (timesteps[1] - timesteps[0])
     print('Finished computing timestep window')
 else:
-    velbarPath = (vpt.globFile('velbar*{}*'.format(args.timestep), args.barfiledir))
+    velbarPath = (vpt.globFile('velbar*.{}*'.format(args.timestep), args.barfiledir))
     print('Using data files:\n\t{}'.format(velbarPath))
     velbarArray = velbarReader(velbarPath)
 
     if not args.velonly:
-        stsbarPath = (vpt.globFile('stsbar*{}*'.format(args.timestep), args.barfiledir))
+        stsbarPath = (vpt.globFile('stsbar*.{}*'.format(args.timestep), args.barfiledir))
         print('\t{}'.format(stsbarPath))
         stsbarArray = stsbarReader(stsbarPath)
 


### PR DESCRIPTION
Previous glob string wasn't strict enough, so it needed replacing.

While at it, I added the `--velbar` and `--stsbar` flags to `bar2vtk` to allow for explicit selection of the paths to each respective files. They also allow for two files to be given in the case of creating split time windows.