### PR TITLE
Fix: Make sampleProfile return Profile type given PointID

### DIFF
--- a/vtkpytools/barfiletools/data.py
+++ b/vtkpytools/barfiletools/data.py
@@ -207,7 +207,7 @@ def sampleDataBlockProfile(dataBlock, line_walldists, pointid=None,
     cutterobj : vtk.vtkPlane, optional
         VTK object that defines the profile location via intersection with the
         'wall'
-    normal : numpy.ndarray
+    normal : numpy.ndarray, optional
         If given, use this vector as the wall normal.
 
     Returns
@@ -232,6 +232,9 @@ def sampleDataBlockProfile(dataBlock, line_walldists, pointid=None,
         sample_line = pv.lines_from_points(sample_points)
         sample_line = sample_line.sample(dataBlock['grid'])
         sample_line['WallDistance'] = line_walldists
+
+        sample_line = Profile(sample_line)
+        sample_line.setWallDataFromPointID(wall, pointid)
 
     if cutterobj:
         cutterout = vCutter(wall, cutterobj)

--- a/vtkpytools/common.py
+++ b/vtkpytools/common.py
@@ -96,6 +96,13 @@ class Profile(pv.PolyData):
         self.walldata = dict(PolyPoint.point_arrays)
         self.walldata['Point'] = PolyPoint.points
 
+    def setWallDataFromPointID(self, wall, pointid):
+        """Set walldata attribute from point id of wall point """
+
+        for array_name in wall.array_names:
+            self.walldata[array_name] = wall[array_name][pointid]
+        self.walldata['Point'] = wall.points[pointid]
+
 def readBinaryArray(path, ncols) -> np.ndarray:
     """Get array from Fortran binary file.
 


### PR DESCRIPTION
When `vpt.sampleDataBlockProfile` is given a `pointid`, it returns a `pv.PolyData` object rather than a `vpt.Profile` object.