### PR TITLE
Fix: Rotate tensor

### DIFF
--- a/vtkpytools/barfiletools/data.py
+++ b/vtkpytools/barfiletools/data.py
@@ -207,7 +207,7 @@ def sampleDataBlockProfile(dataBlock, line_walldists, pointid=None,
     cutterobj : vtk.vtkPlane, optional
         VTK object that defines the profile location via intersection with the
         'wall'
-    normal : numpy.ndarray
+    normal : numpy.ndarray, optional
         If given, use this vector as the wall normal.
 
     Returns

--- a/vtkpytools/common.py
+++ b/vtkpytools/common.py
@@ -200,7 +200,7 @@ def rotateTensor(tensor_array, rotation_tensor) -> np.ndarray:
     """
 
     def rank2Rotation(rot_tensor, shaped_tensors):
-        return np.einsum('ki,lj,ekl->eij', rot_tensor, rot_tensor, shaped_tensors)
+        return np.einsum('ik,ekl,jl->eij', rot_tensor, shaped_tensors, rot_tensor)
 
     if tensor_array.shape[1] == 3 and tensor_array.ndim == 2:
         return np.einsum('ij,ej->ei', rotation_tensor, tensor_array)


### PR DESCRIPTION
Rotating a rank 2 tensor resulted in incorrect data. Was incidentally computing:
![image](https://user-images.githubusercontent.com/20801821/92515298-a01d7c80-f1d0-11ea-9d5f-01c2a15c1022.png)
instead of
![image](https://user-images.githubusercontent.com/20801821/92515329-aa3f7b00-f1d0-11ea-8d08-2a907d2c5a1a.png)

where **a** is the rotation tensor and **R** is the rank 2 tensor to be rotated. 