### PR TITLE
fix(barfiletools): pointid truthiness fixed

### DIFF
--- a/vtkpytools/barfiletools/data.py
+++ b/vtkpytools/barfiletools/data.py
@@ -219,10 +219,10 @@ def sampleDataBlockProfile(dataBlock, line_walldists, pointid=None,
 
     if 'Normals' not in wall.array_names:
         raise RuntimeError('The wall object must have a "Normals" field present.')
-    if not pointid and not cutterobj:
+    if not isinstance(pointid, int) and not cutterobj:
         raise RuntimeError('Must provide either pointid or cutterobj.')
 
-    if pointid:
+    if isinstance(pointid, int):
         wallnormal = wall['Normals'][pointid,:] if normal is None else normal
         wallnormal = np.tile(wallnormal, (len(line_walldists),1))
 


### PR DESCRIPTION
Originally, `sampleDataBlockProfile` checked whether `pointid` was given as an argument was tested via the variables ["truthiness"](https://stackoverflow.com/questions/39983695/what-is-truthy-and-falsy-how-is-it-different-from-true-and-false). Thus, it would fail if it was 0. 

Changed to using `isinstance(pointid, int)` instead to be more strict and not fail unexpectedly.