### PR TITLE
fix(bar2vtk): Remove incorrect TKE calculation

### DIFF
--- a/bin/bar2vtk.py
+++ b/bin/bar2vtk.py
@@ -153,7 +153,6 @@ grid['Velocity'] = velbarArray[:,1:4]
 if not args.velonly:
     ReyStrTensor = vpt.calcReynoldsStresses(stsbarArray, velbarArray)
     grid['ReynoldsStress'] = ReyStrTensor
-    grid['TurbulentEnergyKinetic'] = (1/3)*(np.sum(ReyStrTensor[:,0:3], axis=1))
 
 if args.debug and not args.velonly:
     grid['stsbar'] = stsbarArray


### PR DESCRIPTION
 - Previous calculation of turbulent kinetic energy was incorrect (using 1/3 instead of 1/2)
 - Calculation removed entirely to:
     1. Minimize dependencies in the code (ie. trust the user more than the programmer)
     2. Allow easy way to determine if loaded vtm file has correct/incorrect TKE calcuation (ie. if it has a 'TurbulentEnergyKinetic' array, then it is the wrong calculation).
     3. Reduce file size of the loaded vtm file (not overly significant, but a pro nonetheless) 