### PR TITLE
feat(bar2vtk): Add toml support

### DIFF
--- a/bin/bar2vtk.py
+++ b/bin/bar2vtk.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
 import vtkpytools as vpt
 
-args = vpt.bar2vtk_parse()
+argsdict = vpt.bar2vtk_parse()
 
-vpt.bar2vtk(vtkfile = args.vtkfile,
-barfiledir = args.barfiledir,
-timestep = args.timestep,
-ts0 = args.ts0,
-new_file_prefix = args.new_file_prefix,
-outpath = args.outpath,
-velonly = args.velonly,
-debug = args.debug,
-asciibool = args.ascii,
-velbar = args.velbar,
-stsbar = args.stsbar)
+argsdict['asciidata'] = argsdict.pop('ascii')
+for key in list(argsdict.keys()):
+    if key not in vpt.bar2vtk.__code__.co_varnames:
+        del argsdict[key]
+
+vpt.bar2vtk(**argsdict)
+
+# vpt.bar2vtk(vtkfile = args.vtkfile,
+# barfiledir = args.barfiledir,
+# timestep = args.timestep,
+# ts0 = args.ts0,
+# new_file_prefix = args.new_file_prefix,
+# outpath = args.outpath,
+# velonly = args.velonly,
+# debug = args.debug,
+# asciidata = args.ascii,
+# velbar = args.velbar,
+# stsbar = args.stsbar)

--- a/bin/bar2vtk.py
+++ b/bin/bar2vtk.py
@@ -1,14 +1,26 @@
 #!/usr/bin/env python3
 import vtkpytools as vpt
 
-argsdict = vpt.bar2vtk_parse()
+# vpt.bar2vtk_bin()
+#
 
-argsdict['asciidata'] = argsdict.pop('ascii')
-for key in list(argsdict.keys()):
-    if key not in vpt.bar2vtk.__code__.co_varnames:
-        del argsdict[key]
+from pathlib import Path, PurePath
+test = {'vtkfile': Path('result/exampleMesh.vtm'), 'barfiledir': Path('data'), 'timestep': '10000', 'ts0': -1, 'new_ file_prefix': None, 'outpath': None, 'velonly': False, 'debug': False, 'velbar': [], 'stsbar': [], 'asciidata': False,
+        'list': [Path('~/gitRepos'), Path('/projects'), 'fjfj']}
+convertArray = [(PurePath, lambda x: x.as_posix()),
+                (type(None), lambda x: '')
+                ]
+vpt.barfiletools.bar2vtk._convertArray2TomlTypes(test, convertArray)
+print(test)
 
-vpt.bar2vtk(**argsdict)
+# argsdict = vpt.bar2vtk_parse()
+
+# argsdict['asciidata'] = argsdict.pop('ascii')
+# for key in list(argsdict.keys()):
+#     if key not in vpt.bar2vtk.__code__.co_varnames:
+#         del argsdict[key]
+
+# vpt.bar2vtk(**argsdict)
 
 # vpt.bar2vtk(vtkfile = args.vtkfile,
 # barfiledir = args.barfiledir,

--- a/bin/bar2vtk.py
+++ b/bin/bar2vtk.py
@@ -1,35 +1,4 @@
 #!/usr/bin/env python3
 import vtkpytools as vpt
 
-# vpt.bar2vtk_bin()
-#
-
-from pathlib import Path, PurePath
-test = {'vtkfile': Path('result/exampleMesh.vtm'), 'barfiledir': Path('data'), 'timestep': '10000', 'ts0': -1, 'new_ file_prefix': None, 'outpath': None, 'velonly': False, 'debug': False, 'velbar': [], 'stsbar': [], 'asciidata': False,
-        'list': [Path('~/gitRepos'), Path('/projects'), 'fjfj']}
-convertArray = [(PurePath, lambda x: x.as_posix()),
-                (type(None), lambda x: '')
-                ]
-vpt.barfiletools.bar2vtk._convertArray2TomlTypes(test, convertArray)
-print(test)
-
-# argsdict = vpt.bar2vtk_parse()
-
-# argsdict['asciidata'] = argsdict.pop('ascii')
-# for key in list(argsdict.keys()):
-#     if key not in vpt.bar2vtk.__code__.co_varnames:
-#         del argsdict[key]
-
-# vpt.bar2vtk(**argsdict)
-
-# vpt.bar2vtk(vtkfile = args.vtkfile,
-# barfiledir = args.barfiledir,
-# timestep = args.timestep,
-# ts0 = args.ts0,
-# new_file_prefix = args.new_file_prefix,
-# outpath = args.outpath,
-# velonly = args.velonly,
-# debug = args.debug,
-# asciidata = args.ascii,
-# velbar = args.velbar,
-# stsbar = args.stsbar)
+vpt.bar2vtk_bin()

--- a/bin/bar2vtk.py
+++ b/bin/bar2vtk.py
@@ -50,10 +50,6 @@ parser.add_argument('--stsbar', help='Path to stsbar file(s)', type=Path, nargs=
 
 args = parser.parse_args()
 
-import numpy as np
-import vtk
-import pyvista as pv
-
 # import the package in this repository
 import sys
 if args.vptpath:
@@ -64,107 +60,14 @@ sys.path.insert(0, vptPath.as_posix())
 
 import vtkpytools as vpt
 
-## ---- Process/check script arguments
-assert args.vtkfile.is_file()
-assert args.barfiledir.is_dir()
-
-if args.debug and args.velonly:
-    raise RuntimeError('--velonly counteracts the effect of --debug. Choose one or the other.')
-
-if not len(args.velbar) == len(args.stsbar):
-    raise ValueError('--velbar and --stsbar must be given same number of paths'
-                     ', given {} and {}, respectively'.format(len(args.velbar), len(args.stsbar)))
-
-for flag, arg in {'--velbar':args.velbar, '--stsbar':args.stsbar}.items():
-    if len(arg) > 2:
-        pathStrings = '\n\t' + '\n\t'.join([x.as_posix() for x in arg])
-        raise ValueError('{} can only contain two paths max.'
-                        ' The following were given:{}'.format(flag, pathStrings))
-
-    if len(arg) == 2 and not '-' in args.timestep:
-        raise ValueError('{} was given two paths, but timestep was not given range.'.format(flag))
-
-if args.new_file_prefix:
-    vtmName = Path(args.new_file_prefix + '_' + args.timestep + '.vtm')
-else:
-    vtmName = Path(os.path.splitext(args.vtkfile.name)[0] + '_' + args.timestep + '.vtm')
-
-vtmPath = (args.outpath if args.outpath else args.vtkfile.parent) / vtmName
-
-velbarReader = np.loadtxt if args.ascii else vpt.binaryVelbar
-stsbarReader = np.loadtxt if args.ascii else vpt.binaryStsbar
-
-## ---- Loading data arrays
-if '-' in args.timestep:
-# Create timestep windows
-    if args.ts0 == -1:
-        raise RuntimeError("Starting timestep of bar field averaging required (--ts0)")
-
-    timesteps = [int(x) for x in args.timestep.split('-')]
-    print('Creating timewindow between {} and {}'.format(timesteps[0], timesteps[1]))
-    if not args.velbar:
-        velbarPaths = []; stsbarPaths = []
-        for timestep in timesteps:
-            velbarPaths.append(vpt.globFile('velbar*.{}*'.format(timestep), args.barfiledir))
-
-            if not args.velonly:
-                stsbarPaths.append(vpt.globFile('stsbar*.{}*'.format(timestep), args.barfiledir))
-    else:
-        velbarPaths = args.velbar
-        stsbarPaths = args.stsbar
-
-    print('Using data files:\n\t{}\t{}'.format(velbarPaths[0], velbarPaths[1]))
-    if not args.velonly:
-        print('\t{}\t{}'.format(stsbarPaths[0], stsbarPaths[1]))
-
-    velbarArrays = []; stsbarArrays = []
-    for i in range(2):
-        velbarArrays.append(velbarReader(velbarPaths[i]))
-        if not args.velonly:
-            stsbarArrays.append(stsbarReader(stsbarPaths[i]))
-
-    velbarArray = (velbarArrays[1]*(timesteps[1] - args.ts0) -
-                   velbarArrays[0]*(timesteps[0] - args.ts0)) / (timesteps[1] - timesteps[0])
-    if not args.velonly:
-        stsbarArray = (stsbarArrays[1]*(timesteps[1] - args.ts0) -
-                       stsbarArrays[0]*(timesteps[0] - args.ts0)) / (timesteps[1] - timesteps[0])
-    print('Finished computing timestep window')
-else:
-    velbarPath = args.velbar if args.velbar else \
-        (vpt.globFile('velbar*.{}*'.format(args.timestep), args.barfiledir))
-    print('Using data files:\n\t{}'.format(velbarPath))
-    velbarArray = velbarReader(velbarPath)
-
-    if not args.velonly:
-        stsbarPath = args.stsbar if args.stsbar else \
-            (vpt.globFile('stsbar*.{}*'.format(args.timestep), args.barfiledir))
-        print('\t{}'.format(stsbarPath))
-        stsbarArray = stsbarReader(stsbarPath)
-
-## ---- Load DataBlock
-dataBlock = pv.MultiBlock(args.vtkfile.as_posix())
-grid = dataBlock['grid']
-wall = dataBlock['wall']
-
-## ---- Load *bar data into dataBlock
-grid['Pressure'] = velbarArray[:,0]
-grid['Velocity'] = velbarArray[:,1:4]
-
-if not args.velonly:
-    ReyStrTensor = vpt.calcReynoldsStresses(stsbarArray, velbarArray)
-    grid['ReynoldsStress'] = ReyStrTensor
-
-if args.debug and not args.velonly:
-    grid['stsbar'] = stsbarArray
-
-grid = grid.compute_gradient(scalars='Velocity')
-grid = vpt.compute_vorticity(grid, scalars='Velocity')
-
-## ---- Copy data from grid to wall object
-wall = wall.sample(grid)
-
-dataBlock['grid'] = grid
-dataBlock['wall'] = wall
-print('Saving dataBlock file to: {}'.format(vtmPath), end='')
-dataBlock.save(vtmPath)
-print('\tDone!')
+vpt.bar2vtk(vtkfile = args.vtkfile,
+barfiledir = args.barfiledir,
+timestep = args.timestep,
+ts0 = args.ts0,
+new_file_prefix = args.new_file_prefix,
+outpath = args.outpath,
+velonly = args.velonly,
+debug = args.debug,
+asciibool = args.ascii,
+velbar = args.velbar,
+stsbar = args.stsbar)

--- a/bin/bar2vtk.py
+++ b/bin/bar2vtk.py
@@ -1,64 +1,7 @@
 #!/usr/bin/env python3
-import argparse
-from pathlib import Path
-import os
-
-Description=""" Create a new VTK file from the *bar files and an existing VTK file of
-the mesh.
-
-Examples:
-\tbar2vtk.py blankDataBlock.vtm BinaryBars 10000
-\tbar2vtk.py blankDataBlock.vtm BinaryBars 10000-20000 --ts0=500
-
-The name of the output file will be the same as the blank VTM file suffixed
-with the timestep requested. So in the first example above, the output would be
-"blankDataBlock_10000.vtm".
-
-Time Step Windows:
-------------------
-Submit a timestep argument with a '-' in it to request a timestep window be
-generated. This requires a '--ts0' argument be provided as well for calculating
-the windowed value."""
-
-## Parsing script input
-class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-    """To display defaults in help and have a multiline help description"""
-    # Shamelessly ripped from https://stackoverflow.com/a/18462760/7564988
-    pass
-
-parser = argparse.ArgumentParser(description=Description,
-                                 formatter_class=CustomFormatter,
-                                 prog='bar2vtk')
-parser.add_argument('vtkfile', help='MultiBlock VTK file that contains grid and wall', type=Path)
-parser.add_argument('barfiledir', help='Path to *bar file directory', type=Path)
-parser.add_argument('timestep', help='Timestep of the barfiles. May be range', type=str)
-parser.add_argument('--ts0','--bar-average-start',
-                    help='Starting timestep of the averaging process. Only used'
-                         ' for generating windows.',
-                    type=int, default=-1)
-parser.add_argument('-f','--new-file-prefix',
-                    help='Prefix for the new file. Will have timestep appended.',
-                    type=str)
-parser.add_argument('--outpath', help='Custom path for the output VTM file.'
-                                      ' vtkfile path used if not given', type=Path)
-parser.add_argument('--velonly', help='Only process velbar file', action='store_true')
-parser.add_argument('--debug', help='Load raw stsbar data into VTM', action='store_true')
-parser.add_argument('--vptpath', help='Custom path to vtkpytools package', type=Path)
-parser.add_argument('-a', '--ascii', help='Read *bar files as ASCII', action='store_true')
-parser.add_argument('--velbar', help='Path to velbar file(s)', type=Path, nargs='+', default=[])
-parser.add_argument('--stsbar', help='Path to stsbar file(s)', type=Path, nargs='+', default=[])
-
-args = parser.parse_args()
-
-# import the package in this repository
-import sys
-if args.vptpath:
-    vptPath = args.vptpath
-else:
-    vptPath = Path(__file__).resolve().parent.parent
-sys.path.insert(0, vptPath.as_posix())
-
 import vtkpytools as vpt
+
+args = vpt.bar2vtk_parse()
 
 vpt.bar2vtk(vtkfile = args.vtkfile,
 barfiledir = args.barfiledir,

--- a/example/bar2vtk/runbar2vtk.sh
+++ b/example/bar2vtk/runbar2vtk.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-../../bin/bar2vtk.py result/exampleMesh.vtm data 10000
+../../bin/bar2vtk.py cli result/exampleMesh.vtm data 10000

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,10 @@ setuptools.setup(
     scripts = scripts_hack(
         ('./bin/bar2vtk.py', 'bar2vtk'),
         ('./bin/barsplit.py', 'barsplit')
-    )
+    ),
+    install_requires = [
+        'pyvista',
+        'numpy',
+        'pytomlpp'
+    ]
 )

--- a/vtkpytools/barfiletools/__init__.py
+++ b/vtkpytools/barfiletools/__init__.py
@@ -2,6 +2,6 @@ from .core import form2DGrid, computeEdgeNormals
 from .data import (binaryVelbar, binaryStsbar, calcCf, calcReynoldsStresses,
                    compute_vorticity, sampleDataBlockProfile, calcWallShearGradient,
                    wallAlignRotationTensor)
-from .bar2vtk import bar2vtk
+from .bar2vtk import bar2vtk, bar2vtk_parse
 
 __name__ = "barfiletools"

--- a/vtkpytools/barfiletools/__init__.py
+++ b/vtkpytools/barfiletools/__init__.py
@@ -2,5 +2,6 @@ from .core import form2DGrid, computeEdgeNormals
 from .data import (binaryVelbar, binaryStsbar, calcCf, calcReynoldsStresses,
                    compute_vorticity, sampleDataBlockProfile, calcWallShearGradient,
                    wallAlignRotationTensor)
+from .bar2vtk import bar2vtk
 
 __name__ = "barfiletools"

--- a/vtkpytools/barfiletools/__init__.py
+++ b/vtkpytools/barfiletools/__init__.py
@@ -2,6 +2,6 @@ from .core import form2DGrid, computeEdgeNormals
 from .data import (binaryVelbar, binaryStsbar, calcCf, calcReynoldsStresses,
                    compute_vorticity, sampleDataBlockProfile, calcWallShearGradient,
                    wallAlignRotationTensor)
-from .bar2vtk import bar2vtk, bar2vtk_parse
+from .bar2vtk import bar2vtk_function, bar2vtk_parse, bar2vtk_bin
 
 __name__ = "barfiletools"

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -248,7 +248,7 @@ def bar2vtk_function(vtkfile: Path, barfiledir: Path, timestep: str, \
 
         return tomlMetadata
 
-def tomlReciept(args: dict, tomlMetadata: dict):
+def tomlReceipt(args: dict, tomlMetadata: dict):
 
     convertArray = [(PurePath, lambda x: x.as_posix()),
                     (type(None), lambda x: '')

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -319,8 +319,6 @@ def tomlReceipt(args: dict, tomlMetadata: dict):
                       RuntimeWarning)
     else:
         tomlPath = vtmDir / Path('receipt.toml')
-        print(vtmDir)
-        print(tomlPath)
         with tomlPath.open(mode='w') as file:
             pytomlpp.dump(tomldict, file)
 

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -69,7 +69,6 @@ def bar2vtk_parse():
     cliparser = subparser.add_parser('cli', description=CLIDescription,
                                      formatter_class=CustomFormatter,
                                      help='Command Line Interface mode uses standard flags and cli arguments')
-    # cliparser.set_defaults(which='cli')
 
     cliparser.add_argument('vtkfile', help="MultiBlock VTK file that contains 'grid' and 'wall'", type=Path)
     cliparser.add_argument('barfiledir', help='Path to *bar file directory', type=Path)
@@ -93,7 +92,6 @@ def bar2vtk_parse():
     # Toml Parser Setup
     tomlparser = subparser.add_parser('toml', description=TomlDescription, formatter_class=CustomFormatter,
                                       help='Toml mode uses configuration files in the toml format')
-    # tomlparser.set_defaults(which='toml')
     tomlsubparser = tomlparser.add_subparsers()
     blanktoml = tomlsubparser.add_parser('blank', description='Blank Toml', formatter_class=CustomFormatter,
                                       help='Create blank toml')

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -140,13 +140,13 @@ def bar2vtk_function(vtkfile: Path, barfiledir: Path, timestep: str, \
     assert barfiledir.is_dir()
 
     if debug and velonly:
-        raise RuntimeError('--velonly counteracts the effect of --debug. Choose one or the other.')
+        raise RuntimeError('velonly counteracts the effect of debug. Choose one or the other.')
 
     if not len(velbar) == len(stsbar):
-        raise ValueError('--velbar and --stsbar must be given same number of paths'
+        raise ValueError('velbar and stsbar must be given same number of paths'
                         ', given {} and {}, respectively'.format(len(velbar), len(stsbar)))
 
-    for flag, arg in {'--velbar':velbar, '--stsbar':stsbar}.items():
+    for flag, arg in {'velbar':velbar, 'stsbar':stsbar}.items():
         if len(arg) > 2:
             pathStrings = '\n\t' + '\n\t'.join([x.as_posix() for x in arg])
             raise ValueError('{} can only contain two paths max.'
@@ -169,7 +169,7 @@ def bar2vtk_function(vtkfile: Path, barfiledir: Path, timestep: str, \
     if '-' in timestep:
     # Create timestep windows
         if ts0 == -1:
-            raise RuntimeError("Starting timestep of bar field averaging required (--ts0)")
+            raise RuntimeError("Starting timestep of bar field averaging required (ts0)")
 
         timesteps = [int(x) for x in timestep.split('-')]
         print('Creating timewindow between {} and {}'.format(timesteps[0], timesteps[1]))

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -63,6 +63,7 @@ def bar2vtk_parse():
     parser = argparse.ArgumentParser(description=GeneralDescription,
                                     formatter_class=CustomFormatter,
                                     prog='bar2vtk')
+    parser.add_argument('-v', '--version', action='version', version=__version__)
     subparser = parser.add_subparsers(title='Modes', description=ModeDescription, dest='subparser_name')
 
     # CLI Parser Setup
@@ -92,10 +93,7 @@ def bar2vtk_parse():
     # Toml Parser Setup
     tomlparser = subparser.add_parser('toml', description=TomlDescription, formatter_class=CustomFormatter,
                                       help='Toml mode uses configuration files in the toml format')
-    tomlsubparser = tomlparser.add_subparsers()
-    blanktoml = tomlsubparser.add_parser('blank', description='Blank Toml', formatter_class=CustomFormatter,
-                                      help='Create blank toml')
-    blanktoml.set_defaults(blank=True)
+    tomlparser.add_argument('-b', '--blank', help='Create blank toml', action='store_true')
     tomlparser.add_argument('tomlfile', nargs='?', help='Run bar2vtk using toml config file')
 
     args = vars(parser.parse_args())

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -266,7 +266,9 @@ def tomlReciept(args: dict, tomlMetadata: dict):
 
     tomldict = {'arguments': args}
 
-    meta = {'created': datetime.datetime.now()}
+    meta = {}
+    meta['bar2vtk_vars'] = tomlMetadata
+    meta['created'] = datetime.datetime.now()
     meta['vtkpytools_version'] = __version__
     meta['pyvista_version'] = pv.__version__
     meta['vtk.VTK_VERSION'] = vtk.VTK_VERSION

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -257,7 +257,6 @@ def tomlReceipt(args: dict, tomlMetadata: dict):
     _convertArray2TomlTypes(args, convertArray)
 
     vtmPath = tomlMetadata['vtmPath']
-    del tomlMetadata['vtmPath']
     _convertArray2TomlTypes(tomlMetadata, convertArray)
 
     tomldict = {'arguments': args}
@@ -267,7 +266,7 @@ def tomlReceipt(args: dict, tomlMetadata: dict):
     meta['created'] = datetime.datetime.now()
     meta['vtkpytools_version'] = __version__
     meta['pyvista_version'] = pv.__version__
-    meta['vtk.VTK_VERSION'] = vtk.VTK_VERSION
+    meta['vtk_version'] = vtk.VTK_VERSION
     meta['python_version'] = platform.python_version()
     meta['uname'] = platform.uname()._asdict()
 

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -258,18 +258,11 @@ def tomlReciept(args: dict, tomlMetadata: dict):
                     (type(None), lambda x: '')
                     ]
 
-    # Convert Path objects to string for toml writing
-    # for key, val in args.items():
-    #     _convert2TomlTypes(val, convertArray)
-    #     if isinstance(val, list):
-    #         for subval in val:
-    #             _convert2TomlTypes(val, convertArray)
     _convertArray2TomlTypes(args, convertArray)
 
     vtmPath = tomlMetadata['vtmPath']
     del tomlMetadata['vtmPath']
     _convertArray2TomlTypes(tomlMetadata, convertArray)
-    print(args)
 
     tomldict = {'arguments': args}
 

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -1,17 +1,104 @@
-import numpy as np
-import vtk
-import os
+import vtk, os, argparse
 import pyvista as pv
+import numpy as np
 from pathlib import Path
-import vtkpytools as vpt
+
 from .data import binaryVelbar, binaryStsbar, calcReynoldsStresses, compute_vorticity
 from ..common import globFile
+
+def bar2vtk_parse():
+    Description=""" Create a new VTK file from the *bar files and an existing VTK file of
+    the mesh.
+
+    Examples:
+    \tbar2vtk.py blankDataBlock.vtm BinaryBars 10000
+    \tbar2vtk.py blankDataBlock.vtm BinaryBars 10000-20000 --ts0=500
+
+    The name of the output file will be the same as the blank VTM file suffixed
+    with the timestep requested. So in the first example above, the output would be
+    "blankDataBlock_10000.vtm".
+
+    Time Step Windows:
+    ------------------
+    Submit a timestep argument with a '-' in it to request a timestep window be
+    generated. This requires a '--ts0' argument be provided as well for calculating
+    the windowed value."""
+
+    ## Parsing script input
+    class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+        """To display defaults in help and have a multiline help description"""
+        # Shamelessly ripped from https://stackoverflow.com/a/18462760/7564988
+        pass
+
+    parser = argparse.ArgumentParser(description=Description,
+                                    formatter_class=CustomFormatter,
+                                    prog='bar2vtk')
+    parser.add_argument('vtkfile', help='MultiBlock VTK file that contains grid and wall', type=Path)
+    parser.add_argument('barfiledir', help='Path to *bar file directory', type=Path)
+    parser.add_argument('timestep', help='Timestep of the barfiles. May be range', type=str)
+    parser.add_argument('--ts0','--bar-average-start',
+                        help='Starting timestep of the averaging process. Only used'
+                            ' for generating windows.',
+                        type=int, default=-1)
+    parser.add_argument('-f','--new-file-prefix',
+                        help='Prefix for the new file. Will have timestep appended.',
+                        type=str)
+    parser.add_argument('--outpath', help='Custom path for the output VTM file.'
+                                        ' vtkfile path used if not given', type=Path)
+    parser.add_argument('--velonly', help='Only process velbar file', action='store_true')
+    parser.add_argument('--debug', help='Load raw stsbar data into VTM', action='store_true')
+    parser.add_argument('--vptpath', help='Custom path to vtkpytools package', type=Path)
+    parser.add_argument('-a', '--ascii', help='Read *bar files as ASCII', action='store_true')
+    parser.add_argument('--velbar', help='Path to velbar file(s)', type=Path, nargs='+', default=[])
+    parser.add_argument('--stsbar', help='Path to stsbar file(s)', type=Path, nargs='+', default=[])
+
+    return parser.parse_args()
+
+    # bar2vtk(vtkfile = args.vtkfile,
+    # barfiledir = args.barfiledir,
+    # timestep = args.timestep,
+    # ts0 = args.ts0,
+    # new_file_prefix = args.new_file_prefix,
+    # outpath = args.outpath,
+    # velonly = args.velonly,
+    # debug = args.debug,
+    # asciibool = args.ascii,
+    # velbar = args.velbar,
+    # stsbar = args.stsbar)
 
 def bar2vtk(vtkfile: Path, barfiledir: Path, timestep: str, \
             ts0: int=-1,  new_file_prefix: str='', outpath: Path=None, \
             velonly=False, debug=False, asciibool=False, \
             velbar=[],     stsbar=[]):
+    """Convert velbar and stsbar files into 2D vtk files
 
+    See bar2vtk_commandline help documentation for more information.
+
+    Parameters
+    ----------
+    vtkfile : Path
+        vtkfile
+    barfiledir : Path
+        barfiledir
+    timestep : str
+        timestep
+    ts0 : int
+        ts0
+    new_file_prefix : str
+        new_file_prefix
+    outpath : Path
+        outpath
+    velonly :
+        velonly
+    debug :
+        debug
+    asciibool :
+        asciibool
+    velbar :
+        velbar
+    stsbar :
+        stsbar
+    """
 
     ## ---- Process/check script arguments
     assert vtkfile.is_file()

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -103,7 +103,6 @@ def bar2vtk_parse():
                                         ' blankvtmfile path used if not given', type=Path)
     cliparser.add_argument('--velonly', help='Only process velbar file', action='store_true')
     cliparser.add_argument('--debug', help='Load raw stsbar data into VTM', action='store_true')
-    cliparser.add_argument('--vptpath', help='Custom path to vtkpytools package', type=Path)
     cliparser.add_argument('-a', '--ascii', help='Read *bar files as ASCII', action='store_true')
     cliparser.add_argument('--velbar', help='Path to velbar file(s)', type=Path, nargs='+', default=[])
     cliparser.add_argument('--stsbar', help='Path to stsbar file(s)', type=Path, nargs='+', default=[])

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -1,0 +1,119 @@
+import numpy as np
+import vtk
+import os
+import pyvista as pv
+from pathlib import Path
+import vtkpytools as vpt
+from .data import binaryVelbar, binaryStsbar, calcReynoldsStresses, compute_vorticity
+from ..common import globFile
+
+def bar2vtk(vtkfile: Path, barfiledir: Path, timestep: str, \
+            ts0: int=-1,  new_file_prefix: str='', outpath: Path=None, \
+            velonly=False, debug=False, asciibool=False, \
+            velbar=[],     stsbar=[]):
+
+
+    ## ---- Process/check script arguments
+    assert vtkfile.is_file()
+    assert barfiledir.is_dir()
+
+    if debug and velonly:
+        raise RuntimeError('--velonly counteracts the effect of --debug. Choose one or the other.')
+
+    if not len(velbar) == len(stsbar):
+        raise ValueError('--velbar and --stsbar must be given same number of paths'
+                        ', given {} and {}, respectively'.format(len(velbar), len(stsbar)))
+
+    for flag, arg in {'--velbar':velbar, '--stsbar':stsbar}.items():
+        if len(arg) > 2:
+            pathStrings = '\n\t' + '\n\t'.join([x.as_posix() for x in arg])
+            raise ValueError('{} can only contain two paths max.'
+                            ' The following were given:{}'.format(flag, pathStrings))
+
+        if len(arg) == 2 and not '-' in timestep:
+            raise ValueError('{} was given two paths, but timestep was not given range.'.format(flag))
+
+    if new_file_prefix:
+        vtmName = Path(new_file_prefix + '_' + timestep + '.vtm')
+    else:
+        vtmName = Path(os.path.splitext(vtkfile.name)[0] + '_' + timestep + '.vtm')
+
+    vtmPath = (outpath if outpath else vtkfile.parent) / vtmName
+
+    velbarReader = np.loadtxt if asciibool else binaryVelbar
+    stsbarReader = np.loadtxt if asciibool else binaryStsbar
+
+    ## ---- Loading data arrays
+    if '-' in timestep:
+    # Create timestep windows
+        if ts0 == -1:
+            raise RuntimeError("Starting timestep of bar field averaging required (--ts0)")
+
+        timesteps = [int(x) for x in timestep.split('-')]
+        print('Creating timewindow between {} and {}'.format(timesteps[0], timesteps[1]))
+        if not velbar:
+            velbarPaths = []; stsbarPaths = []
+            for timestep in timesteps:
+                velbarPaths.append(globFile('velbar*.{}*'.format(timestep), barfiledir))
+
+                if not velonly:
+                    stsbarPaths.append(globFile('stsbar*.{}*'.format(timestep), barfiledir))
+        else:
+            velbarPaths = velbar
+            stsbarPaths = stsbar
+
+        print('Using data files:\n\t{}\t{}'.format(velbarPaths[0], velbarPaths[1]))
+        if not velonly:
+            print('\t{}\t{}'.format(stsbarPaths[0], stsbarPaths[1]))
+
+        velbarArrays = []; stsbarArrays = []
+        for i in range(2):
+            velbarArrays.append(velbarReader(velbarPaths[i]))
+            if not velonly:
+                stsbarArrays.append(stsbarReader(stsbarPaths[i]))
+
+        velbarArray = (velbarArrays[1]*(timesteps[1] - ts0) -
+                    velbarArrays[0]*(timesteps[0] - ts0)) / (timesteps[1] - timesteps[0])
+        if not velonly:
+            stsbarArray = (stsbarArrays[1]*(timesteps[1] - ts0) -
+                        stsbarArrays[0]*(timesteps[0] - ts0)) / (timesteps[1] - timesteps[0])
+        print('Finished computing timestep window')
+    else:
+        velbarPath = velbar if velbar else \
+            (globFile('velbar*.{}*'.format(timestep), barfiledir))
+        print('Using data files:\n\t{}'.format(velbarPath))
+        velbarArray = velbarReader(velbarPath)
+
+        if not velonly:
+            stsbarPath = stsbar if stsbar else \
+                (globFile('stsbar*.{}*'.format(timestep), barfiledir))
+            print('\t{}'.format(stsbarPath))
+            stsbarArray = stsbarReader(stsbarPath)
+
+    ## ---- Load DataBlock
+    dataBlock = pv.MultiBlock(vtkfile.as_posix())
+    grid = dataBlock['grid']
+    wall = dataBlock['wall']
+
+    ## ---- Load *bar data into dataBlock
+    grid['Pressure'] = velbarArray[:,0]
+    grid['Velocity'] = velbarArray[:,1:4]
+
+    if not velonly:
+        ReyStrTensor = calcReynoldsStresses(stsbarArray, velbarArray)
+        grid['ReynoldsStress'] = ReyStrTensor
+
+    if debug and not velonly:
+        grid['stsbar'] = stsbarArray
+
+    grid = grid.compute_gradient(scalars='Velocity')
+    grid = compute_vorticity(grid, scalars='Velocity')
+
+    ## ---- Copy data from grid to wall object
+    wall = wall.sample(grid)
+
+    dataBlock['grid'] = grid
+    dataBlock['wall'] = wall
+    print('Saving dataBlock file to: {}'.format(vtmPath), end='')
+    dataBlock.save(vtmPath)
+    print('\tDone!')

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -22,7 +22,7 @@ def bar2vtk_bin():
 
     elif argsdict['subparser_name'] == 'toml':
         if argsdict['blank']:
-            # blankToml(argsdict['tomlfile'])
+            blankToml(argsdict['tomlfile'])
             return
         assert argsdict['tomlfile'].is_file()
         with argsdict['tomlfile'].open() as tomlfile:
@@ -266,6 +266,26 @@ def bar2vtk_function(blankvtmfile: Path, barfiledir: Path, timestep: str, \
             tomlMetadata['stsbarPaths'] = stsbarPaths
 
         return tomlMetadata
+
+def blankToml(tomlfilepath: Path, returndict=False):
+    """Write blank toml file to tomlfilepath"""
+    tomldict = { 'arguments': {
+        'blankvtmfile': 'path/to/blankVTMFile (required)',
+        'barfiledir': 'path/to/directory/of/*barfiles (required)',
+        'timestep': 'timestep (range) of data (required)',
+        'ts0': -1,
+        'new_file_prefix': '',
+        'outpath': 'path/to/different/output/directory',
+        'velonly': False,
+        'debug': False,
+        'asciidata': False,
+        'velbar': [],
+        'stsbar': [],
+    }}
+
+    with tomlfilepath.open('w') as file:
+        pytomlpp.dump(tomldict, file)
+    if returndict: return tomldict
 
 def tomlReceipt(args: dict, tomlMetadata: dict):
 


### PR DESCRIPTION
Use [`toml` documents](https://toml.io/en/) as configuration files for `bar2vtk` and as "receipt" files to keep track of how a file was created. Todo:

### Receipt should contain:
 - [x] `bar2vtk` input arguments
 - [x] Date/time when file was created
 - [x] Directory where file was run from
 - [x] Package version info
     - [x] vtkpytools
     - [x] pyvista
     - [x] vtk
     - [x] python
- [x] Location of source *bar files
- [x] Information about machine where it was run

### General toml functionality
 - [x] Allow for toml file to be used as input 
 - [x] Print out blank toml
     - [ ] Have commented instructions in blank toml
 - [ ] 

Closes #34 