### PR TITLE
chore: Change version number for master branch

### DIFF
--- a/vtkpytools/_version.py
+++ b/vtkpytools/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.0'
+__version__ = '0.3.dev0'


### PR DESCRIPTION
Give the `master` branch the `dev0` designation to differentiate it from an official release.

Will be particularly important with the addition of the toml receipt files, as they actually keep track of the vtkpytools version they were created with.