### PR TITLE
feat: Add regex capability to globFile, bar2vtk

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 
 import vtkpytools as vpt
+from pathlib import Path
 
 
 @pytest.fixture
@@ -40,3 +41,23 @@ def test_full2SymmetricTensor(symAndFullTensor):
 
     sym_test = vpt.full2SymmetricTensor(full)
     assert np.allclose(sym_test, sym)
+
+@pytest.fixture(params=['', '.1'])
+def createGlobFiles(request, tmp_path):
+    testStrings = ['velbar.20000',
+                   'velbar.20000-30000',
+                   'velbar.200',
+                   'velbar.200-30000']
+    for testString in testStrings:
+        testPath = tmp_path / Path(testString + request.param)
+        testPath.touch()
+
+# Should fail
+def test_globFile_glob(createGlobFiles, tmp_path):
+    with pytest.raises(RuntimeError):
+        vpt.globFile(r'velbar*.200*', tmp_path)
+
+def test_globFile_regex(createGlobFiles, tmp_path):
+    print(list(tmp_path.iterdir()))
+    vpt.globFile(r'^velbar\.200(?![\d|-]).*$', tmp_path, regex=True)
+

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -246,7 +246,7 @@ def getBarData(_bar: list, timestep: str, barfiledir: Path, _barReader,
         if not _bar:
             _barPaths = []
             for timestep in timesteps:
-                _barPaths.append(globFile('{}*.{}*'.format(globname, timestep), barfiledir))
+                _barPaths.append(globFile(r'^{}\.{}(?![\d|-]).*$'.format(globname, timestep), barfiledir))
         else:
             _barPaths = _bar
 


### PR DESCRIPTION
Allow for python regex strings to be used in `globFile` via the `regex` keyword argument (ie. `globfile(r'.*', Path('.'), regex=True)`).
 - Added appropriate tests to check it
 - Closes #47