### PR TITLE
fix(bar2vtk): Fully implement bar2vtk regex globing

### DIFF
--- a/tests/barfiletools/test_bar2vtk.py
+++ b/tests/barfiletools/test_bar2vtk.py
@@ -40,3 +40,8 @@ def fixture_bar2vtk_exampledata(tmp_path):
 def test_bar2vtk_exampledata(fixture_bar2vtk_exampledata, tmp_path):
     sys.argv = 'bar2vtk cli result/exampleMesh.vtm data 10000'.split(' ')
     vpt.bar2vtk_main()
+
+def test_bar2vtk_fileGlobbing(fixture_bar2vtk_exampledata, tmp_path):
+    for testString in ['velbar', 'stsbar']:
+        (tmp_path / 'data/{}.100000.1'.format(testString)).touch()
+    vpt.bar2vtk_main('cli result/exampleMesh.vtm data 10000'.split(' '))

--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -237,16 +237,16 @@ def bar2vtk_function(blankvtmfile: Path, barfiledir: Path, timestep: str, \
 
         return tomlMetadata
 
-def getBarData(_bar: list, timestep: str, barfiledir: Path, _barReader,
+def getBarData(_bar: list, timestep_str: str, barfiledir: Path, _barReader,
                    ts0: int, globname: str):
     """Get array of data from bar2vtk arguments"""
-    if '-' in timestep:
-        timesteps = [int(x) for x in timestep.split('-')]
+    if '-' in timestep_str:
+        timesteps = [int(x) for x in timestep_str.split('-')]
         print('Creating timewindow between {} and {}'.format(timesteps[0], timesteps[1]))
         if not _bar:
             _barPaths = []
             for timestep in timesteps:
-                _barPaths.append(globFile(r'^{}\.{}(?![\d|-]).*$'.format(globname, timestep), barfiledir))
+                _barPaths.append(globFile(r'^{}\.{}(?![\d|-]).*$'.format(globname, timestep), barfiledir, regex=True))
         else:
             _barPaths = _bar
 
@@ -261,7 +261,7 @@ def getBarData(_bar: list, timestep: str, barfiledir: Path, _barReader,
         print('Finished computing timestep window')
     else:
         _barPaths = _bar if _bar else \
-            (globFile('{}*.{}*'.format(globname, timestep), barfiledir))
+            (globFile(r'^{}\.{}(?![\d|-]).*$'.format(globname, timestep_str), barfiledir, regex=True))
         print('\t{}'.format(_barPaths))
         _barArray = _barReader(_barPaths)
 


### PR DESCRIPTION
- Previous version left of the `regex=True` flag when calling `globFile()`.
- Also, for non-timestep windows, regex globing would not have worked
- Added explicit test for bar2vtk globing
    - ie. `velbar.10000` and `velbar.100000` should be differentiated and not error out