### PR TITLE
fix: Correct offset in gridtools2d, use `compute_derivative`

### DIFF
--- a/vtkpytools/barfiletools/bar2vtk.py
+++ b/vtkpytools/barfiletools/bar2vtk.py
@@ -217,8 +217,7 @@ def bar2vtk_function(blankvtmfile: Path, barfiledir: Path, timestep: str, \
     if debug and not velonly:
         grid['stsbar'] = stsbarArray
 
-    grid = grid.compute_gradient(scalars='Velocity')
-    grid = compute_vorticity(grid, scalars='Velocity')
+    grid = grid.compute_derivative(scalars='Velocity', gradient='gradient', vorticity='vorticity')
 
     ## ---- Copy data from grid to wall object
     wall = wall.sample(grid)

--- a/vtkpytools/barfiletools/data.py
+++ b/vtkpytools/barfiletools/data.py
@@ -166,7 +166,14 @@ def calcCf(wall, Uref, nu, rho, plane_normal='XY') -> np.ndarray:
     return Cf
 
 def compute_vorticity(dataset, scalars, vorticity_name='vorticity'):
-    """Compute Vorticity, only needed till my PR gets merged"""
+    """(DEPRECATED) Compute Vorticity, only needed till my PR gets merged
+
+     .. deprecated::
+         Use the `compute_derivative` method in pyvista's `UnstructuredGrid` class
+     """
+
+    warnings.warn("This function is deprecated. Use the 'compute_derivative'"
+                  " method in pyvista's 'UnstructuredGrid' class" , FutureWarning)
     alg = vtk.vtkGradientFilter()
 
     alg.SetComputeVorticity(True)

--- a/vtkpytools/gridtools2d/core.py
+++ b/vtkpytools/gridtools2d/core.py
@@ -60,7 +60,7 @@ def form2DGrid(coords_array, connectivity_array=None) -> pv.UnstructuredGrid:
 
         if cell_type:
             connectivity_array = np.hstack((np.ones((nCells,1), dtype=np.int64)*nPnts, connectivity_array))
-            offsets = np.arange(0, connectivity_array.size+1, nPnts+1, dtype=np.int64)
+            offsets = np.arange(0, connectivity_array.size, nPnts+1, dtype=np.int64)
             cell_types = np.ones(nCells, dtype=np.int64) * cell_type
         else: # quad/tri mesh
             cell_types = repeatedNode*vtk.VTK_TRIANGLE + np.invert(repeatedNode)*vtk.VTK_QUAD


### PR DESCRIPTION
 - Newer versions of pyvista check that `size(offset) == size(cellArray)`,
   which was off by one (but had no consequences actual consequences)

 - Replaced the `compute_gradient` method with `compute_derivative` that I contributed (https://github.com/pyvista/pyvista/pull/837)
     - Also replaces (and thus deprecates) `vpt.compute_vorticity`