### PR TITLE
feat(numtools): sym<->full input check, `...` ability

### DIFF
--- a/tests/test_numtools.py
+++ b/tests/test_numtools.py
@@ -31,19 +31,71 @@ def test_calcStrainRate(twoFullTensors):
     assert np.allclose(strainrate, solution)
     assert strainrate.shape[0] == twoFullTensors.shape[0]
 
+class Test_symmetric2FullTensor():
 
-def test_symmetric2FullTensor(symAndFullTensor):
-    (full, sym) = symAndFullTensor
+    @staticmethod
+    def test_func2d(symAndFullTensor):
+        full, sym = symAndFullTensor
 
-    full_test = vpt.symmetric2FullTensor(sym)
-    assert np.allclose(full_test, full)
+        full_test = vpt.symmetric2FullTensor(sym)
+        assert np.allclose(full_test, full)
+
+    @staticmethod
+    def test_func_Nd(symAndFullTensor):
+        """Test (n,m,6) -> (n,m,3,3)"""
+        full, sym = symAndFullTensor
+
+        sym = sym.reshape((1,-1,6))
+        full = full.reshape((1,-1,3,3))
+        full_test = vpt.symmetric2FullTensor(sym)
+        assert full_test.shape == full.shape
+        assert np.allclose(full_test, full)
+
+        sym = sym.reshape((-1,1,6))
+        full = full.reshape((-1,1,3,3))
+        full_test = vpt.symmetric2FullTensor(sym)
+        assert full_test.shape == full.shape
+        assert np.allclose(full_test, full)
+
+    @staticmethod
+    def test_inputCheck():
+        array = np.empty((6,4))
+        with pytest.raises(Exception):
+            vpt.symmetric2FullTensor(array)
 
 
-def test_full2SymmetricTensor(symAndFullTensor):
-    (full, sym) = symAndFullTensor
+class Test_full2SymmetricTensor():
 
-    sym_test = vpt.full2SymmetricTensor(full)
-    assert np.allclose(sym_test, sym)
+    @staticmethod
+    def test_func3d(symAndFullTensor):
+        full, sym = symAndFullTensor
+
+        sym_test = vpt.full2SymmetricTensor(full)
+        assert sym_test.shape == sym.shape
+        assert np.allclose(sym_test, sym)
+
+    @staticmethod
+    def test_func_Nd(symAndFullTensor):
+        """Test (n,m,3,3) -> (n,m,6)"""
+        full, sym = symAndFullTensor
+
+        sym = sym.reshape((1,-1,6))
+        full = full.reshape((1,-1,3,3))
+        sym_test = vpt.full2SymmetricTensor(full)
+        assert sym_test.shape == sym.shape
+        assert np.allclose(sym_test, sym)
+
+        sym = sym.reshape((-1,1,6))
+        full = full.reshape((-1,1,3,3))
+        sym_test = vpt.full2SymmetricTensor(full)
+        assert sym_test.shape == sym.shape
+        assert np.allclose(sym_test, sym)
+
+    @staticmethod
+    def test_inputCheck():
+        array = np.empty((3,3,4))
+        with pytest.raises(Exception):
+            vpt.full2SymmetricTensor(array)
 
 
 @pytest.mark.parametrize('offset,expected', [(1, [0, 1] ),

--- a/tests/test_numtools.py
+++ b/tests/test_numtools.py
@@ -105,7 +105,7 @@ def test_pwlinRoots(offset, expected):
     y = np.array([-1,   1, -1])
 
     roots = vpt.pwlinRoots(x, y + offset)
-    assert(np.allclose(roots, expected))
+    assert np.allclose(roots, expected)
 
 
 @pytest.mark.parametrize('kwargs,expected', [({'dx': 2.4}, [0, 1, 2, 4, 6.4, 8]),
@@ -115,8 +115,8 @@ def test_seriesDiffLimiter(kwargs, expected):
     series = np.array([0, 1, 2, 4, 8])
 
     result = vpt.seriesDiffLimiter(series, **kwargs)
-    assert(result.size == len(expected))
-    assert(np.allclose(result, expected))
+    assert result.size == len(expected)
+    assert np.allclose(result, expected)
 
 @pytest.mark.parametrize('kwargs', [{},
                                     {'dx': 2.0, 'magnitude': 4.0}])

--- a/vtkpytools/numtools.py
+++ b/vtkpytools/numtools.py
@@ -129,26 +129,36 @@ def seriesDiffLimiter(series: np.ndarray, dx=None, magnitude=None) -> np.ndarray
 
 
 def symmetric2FullTensor(tensor_array) -> np.ndarray:
-    """ Turn (n, 6) shape array of tensor entries into (n, 3, 3)
+    """Turn (..., 6) shape array of tensor entries into (..., 3, 3)
 
     Assumed that symmtetric entires are in XX YY ZZ XY XZ YZ order."""
+    if tensor_array.shape[-1] != 6:
+        raise ValueError('The array is not in symmetric form! '
+                         f'The last axis must be size 6, not {tensor_array.shape[-1]}.')
+
 
     shaped_tensors = np.array([
-                     tensor_array[:,0], tensor_array[:,3], tensor_array[:,4],
-                     tensor_array[:,3], tensor_array[:,1], tensor_array[:,5],
-                     tensor_array[:,4], tensor_array[:,5], tensor_array[:,2]
+                     tensor_array[...,0], tensor_array[...,3], tensor_array[...,4],
+                     tensor_array[...,3], tensor_array[...,1], tensor_array[...,5],
+                     tensor_array[...,4], tensor_array[...,5], tensor_array[...,2]
                     ]).T
-    return shaped_tensors.reshape(shaped_tensors.shape[0], 3, 3)
+    return shaped_tensors.reshape(*tensor_array.shape[:-1], 3, 3)
 
 
 def full2SymmetricTensor(tensor_array) -> np.ndarray:
-    """ Turn (n, 3, 3) shape array of tensor entries into (n, 6)
+    """Turn (..., 3, 3) shape array of tensor entries into (..., 6)
 
-    Symmetric entires are in XX YY ZZ XY XZ YZ order."""
-    return np.array([
-        tensor_array[:,0,0], tensor_array[:,1,1], tensor_array[:,2,2],
-        tensor_array[:,0,1], tensor_array[:,0,2], tensor_array[:,1,2]
-                    ]).T
+    Symmetric entires are in XX YY ZZ XY XZ YZ order.
+    """
+    if tensor_array.shape[-2:] != (3,3):
+        raise ValueError('The array is not in full form! '
+                         f'The last two axis must be shape (3,3), not {tensor_array.shape[-2:]}.')
+
+    shaped_tensors = np.empty((*tensor_array.shape[:-2], 6))
+    indices = [(0,0), (1,1), (2,2), (0,1), (0,2), (1,2)]
+    for i, ind in enumerate(indices):
+        shaped_tensors[...,i] = tensor_array[...,ind[0], ind[1]]
+    return shaped_tensors
 
 
 def makeRotationTensor(rotation_axis, theta) -> np.ndarray:


### PR DESCRIPTION
`symmetric2FullTensor` and `full2SymmetricTensor` were changed by:
 - Adding a input check to verify that the incoming array was of size `(...,6)` or `(...3,3)`, respectively
 - Add ability for the input array to have arbitrary leading dimensionality.
     - 	So an array of shape `(10,100,6)` could be input and transformed to `(10,100,3,3)`
 - Added tests to verify all the above changes.