### PR TITLE
fix: Update for pyvista >0.37.0

### DIFF
--- a/vtkpytools/common.py
+++ b/vtkpytools/common.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.io import FortranFile
 from pathlib import Path
 import re
+from packaging import version
 
 def unstructuredToPoly(unstructured_grid):
     """Convert vtk.UnstructruedGrid to vtk.PolyData"""
@@ -59,7 +60,10 @@ class Profile(pv.PolyData):
         if PolyPoint.n_points != 1:
             raise RuntimeError('Profile should only have 1 wallpoint, {:d} given'.format(
                                                                     PolyPoint.n_points))
-        self.walldata = dict(PolyPoint.point_arrays)
+        if version.parse(pv.__version__) < version.parse('0.37.0'):
+            self.walldata = dict(PolyPoint.point_arrays)
+        else:
+            self.walldata = dict(PolyPoint.point_data)
         self.walldata['Point'] = PolyPoint.points
 
 def readBinaryArray(path, ncols) -> np.ndarray:

--- a/vtkpytools/gridtools2d/core.py
+++ b/vtkpytools/gridtools2d/core.py
@@ -3,6 +3,7 @@ import vtk
 from pathlib import Path
 from scipy.spatial import Delaunay
 import pyvista as pv
+from packaging import version
 
 def form2DGrid(coords_array, connectivity_array=None) -> pv.UnstructuredGrid:
     """Create 2D VTK UnstructuredGrid from coordinates and connectivity
@@ -104,7 +105,6 @@ def computeEdgeNormals(edges, domain_point) -> pv.PolyData:
 
     """
     normals = np.zeros((edges.n_cells, 3))
-    i = 0
         # Indices of 2 points forming line cell
     indices = edges.lines.reshape((edges.n_cells, 3))[:,1:3]
     pnts1 = edges.points[indices[:,0], :]
@@ -122,6 +122,10 @@ def computeEdgeNormals(edges, domain_point) -> pv.PolyData:
     normals = np.einsum('ij,i->ij',normals,inOrOut)
     normals = np.einsum('ij,i->ij', normals, np.linalg.norm(normals, axis=1)**-1)
 
-    edges.cell_arrays['Normals'] = normals
+    if version.parse(pv.__version__) < version.parse('0.37.0'):
+        edges.cell_arrays['Normals'] = normals
+    else:
+        edges.cell_data['Normals'] = normals
+
     return edges
 

--- a/vtkpytools/numtools.py
+++ b/vtkpytools/numtools.py
@@ -111,13 +111,13 @@ def seriesDiffLimiter(series: np.ndarray, dx=None, magnitude=None) -> np.ndarray
         raise RuntimeError('Either dx or magnitude must be set')
     if dx:
         dxs = np.diff(series)
-        index = np.ceil( pwlinRoots(np.arange(dxs.size), dxs - dx)[0] ).astype(np.int)
+        index = np.ceil( pwlinRoots(np.arange(dxs.size), dxs - dx)[0] ).astype(int)
     else:
-        index = np.ceil( pwlinRoots(np.arange(series.size), series - magnitude)[0] ).astype(np.int)
+        index = np.ceil( pwlinRoots(np.arange(series.size), series - magnitude)[0] ).astype(int)
         dx = series[index] - series[index-1]
 
     fill_distance = np.max(series) - series[index]
-    fill_size = np.ceil(fill_distance / dx).astype(np.int)
+    fill_size = np.ceil(fill_distance / dx).astype(int)
     fill_array = np.arange(1, fill_size+1)*dx + series[index]
 
     new_series = np.zeros(index + fill_size + 1)


### PR DESCRIPTION
- That version deprecated the `*.{point,cell}_arrays` in favor of `*.{point,cell}_data`
- Also fixes for deprecated numpy datatypes `np.int` and `np.float`