### PR TITLE
fix(gridtools): Add pyvista version check to avoid warnings

### DIFF
--- a/vtkpytools/gridtools2d/core.py
+++ b/vtkpytools/gridtools2d/core.py
@@ -75,7 +75,11 @@ def form2DGrid(coords_array, connectivity_array=None) -> pv.UnstructuredGrid:
             offsets[0] = 0
             pass
 
-    grid = pv.UnstructuredGrid(offsets, connectivity_array, cell_types, coords_array)
+    if version.parse(pv.__version__) < version.parse('0.37.0'):
+        grid = pv.UnstructuredGrid(offsets, connectivity_array, cell_types, coords_array)
+    else:
+        grid = pv.UnstructuredGrid(connectivity_array, cell_types, coords_array)
+
 
     return grid
 

--- a/vtkpytools/gridtools3d/core.py
+++ b/vtkpytools/gridtools3d/core.py
@@ -2,6 +2,7 @@ import numpy as np
 import vtk
 from pathlib import Path
 import pyvista as pv
+from packaging import version
 
 
 def form3DGrid(coords_array, connectivity_array) -> pv.UnstructuredGrid:
@@ -67,6 +68,9 @@ def form3DGrid(coords_array, connectivity_array) -> pv.UnstructuredGrid:
         offsets = np.roll(np.cumsum(offset+1), 1)
         offsets[0] = 0
 
-    grid = pv.UnstructuredGrid(offsets, connectivity_array, cell_types, coords_array)
+    if version.parse(pv.__version__) < version.parse('0.37.0'):
+        grid = pv.UnstructuredGrid(offsets, connectivity_array, cell_types, coords_array)
+    else:
+        grid = pv.UnstructuredGrid(connectivity_array, cell_types, coords_array)
 
     return grid


### PR DESCRIPTION
Warnings returned were:
```
/home/jrwrigh/gitRepos/vtkpytools/vtkpytools/gridtools2d/core.py:78: UserWarning: VTK 9 no longer accepts an offset array
```